### PR TITLE
Fix rust 1.43 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexasphere"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["OptimisticPeach <patrikbuhring@gmail.com>"]
 edition = "2018"
 description = """

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -33,7 +33,7 @@ impl BaseShape for IcoSphereBase {
 
     #[inline]
     fn triangles(&self) -> Box<[Triangle]> {
-        consts::icosphere::TRIANGLES.into()
+        Box::new(consts::icosphere::TRIANGLES)
     }
     const EDGES: usize = consts::icosphere::EDGES;
 
@@ -111,7 +111,7 @@ impl BaseShape for TetraSphereBase {
 
     #[inline]
     fn triangles(&self) -> Box<[Triangle]> {
-        consts::tetrasphere::TRIANGLES.into()
+        Box::new(consts::tetrasphere::TRIANGLES)
     }
     const EDGES: usize = consts::tetrasphere::EDGES;
 


### PR DESCRIPTION
This change preserves the current MSRV of 1.43 on Bevy. This might be lower for other projects, but this is compatible to at least Rust 1.43.

This closes issue: https://github.com/OptimisticPeach/hexasphere/issues/4