### PR TITLE
Update to latest glam version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["algorithms", "data-structures", "graphics", "mathematics", "rende
 adjacency = ["smallvec"]
 
 [dependencies]
-glam = "0.17"
+glam = "0.18"
 lazy_static = "1.4"
 
 smallvec = { version = "1.4.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexasphere"
-version = "4.1.0"
+version = "4.1.1"
 authors = ["OptimisticPeach <patrikbuhring@gmail.com>"]
 edition = "2018"
 description = """


### PR DESCRIPTION
I want bevyengine to bump to the latest glam version as well, so that it
has support for WASM simd intrinsics, but I can't do so until this
library upgrades.