### PR TITLE
Update `glam` to `0.23`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["algorithms", "data-structures", "graphics", "mathematics", "rende
 adjacency = ["smallvec"]
 
 [dependencies]
-glam = "0.22"
+glam = "0.23"
 once_cell = "1.4"
 
 smallvec = { version = "1.4.2", optional = true }


### PR DESCRIPTION
Since the breaking change only affects the `scalar-math` feature, this should cause no issues.