### PR TITLE
Update `glam` version requirement from 0.27.0 to 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ shape-extras = []
 
 [dependencies]
 constgebra = "0.1.4"
-glam = "0.27.0"
+glam = "0.28.0"
 
 tinyvec = { version = "1.6.0", optional = true }


### PR DESCRIPTION
I'm mainly pushing this change so we can unblock the following PR in `bevy` repo: https://github.com/bevyengine/bevy/pull/13792.

From the only issue filed in this repo I understand this is sub-par but it would be great to have this incorporated and a new version to be cut after it to be able to move the beforementioned update forward.

Checks and tests are passing locally FWIW.