### PR TITLE
Enable cloning of Subdivided

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1722,6 +1722,11 @@ mod tests {
     }
 
     #[test]
+    fn clone() {
+        let _x = IcoSphere::new(0, |_| ()).clone();
+    }
+
+    #[test]
     fn one() {
         let x = IcoSphere::new(1, |_| ());
         x.get_indices(0, &mut Vec::new());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ pub trait EquilateralBaseShape: BaseShape {
 ///
 /// The edge between two main triangles.
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Edge {
     ///
     /// Indices of the points between the endpoints.
@@ -1014,6 +1014,7 @@ impl Triangle {
 /// than or equal to `1.0`. This is why all default shapes
 /// lie on the unit sphere.
 ///
+#[derive(Clone)]
 pub struct Subdivided<T, S: BaseShape> {
     points: Vec<Vec3A>,
     data: Vec<T>,


### PR DESCRIPTION
This change implements `Clone` for `Subdivided` which is convenient if shapes need to be duplicated.