### PR TITLE
Derive Debug for subdivided

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1014,7 +1014,7 @@ impl Triangle {
 /// than or equal to `1.0`. This is why all default shapes
 /// lie on the unit sphere.
 ///
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Subdivided<T, S: BaseShape> {
     points: Vec<Vec3A>,
     data: Vec<T>,


### PR DESCRIPTION
This adds `Debug` to `Subdivided` and should hopefully not break anything. I have a specific use of this in a derived table structure where at each vertex I store data, `T` that may be a float or another icosphere. If both types implement Debug it's trivial to print information from a common function.