### PR TITLE
Re-add the ability to get major edge lines.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexasphere"
-version = "14.0.0"
+version = "14.1.0"
 authors = ["OptimisticPeach <patrikbuhring@gmail.com>"]
 edition = "2021"
 description = """


### PR DESCRIPTION
* Bump version from 14.0.0 (current release) to 14.1.0, because we're adding a method.
* Added back `get_major_edge_line_indices`, which was removed by commit 9ff8564b4cab8b1196a78e3313a0324f4f2e94cc. However, it is (still) buggy (it misses the first and last index), so it is marked deprecated. This is just so that this can go into a release which is a minor rather than major version bump.
* Added replacement `get_major_edges_line_indices` which returns the correct lines. However, it returns *all* relevant edges, rather than allowing selection of a single edge.
* Removed unused `use std::sync::Arc;`.