### PR TITLE
Improve handling of `tinyvec` dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ categories = [
 
 [features]
 default = ["std"]
-std = ["glam/std", "tinyvec/std"]
-adjacency = ["tinyvec"]
+std = ["glam/std", "tinyvec?/std"]
+adjacency = ["dep:tinyvec"]
 shape-extras = []
 libm = ["dep:libm", "glam/libm"]
 


### PR DESCRIPTION
* Use `dep:` syntax for enabling the `tinyvec` dependency. This avoids creating an implicit feature (that shows up when using `cargo add hexasphere`).
* Use the `?` syntax when enabling the `std` feature so that enabling the `std` feature in `hexasphere` only enables it in `tinyvec` when `tinyvec` is itself enabled.