### PR TITLE
Added Serde feature and optionnal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ std = ["glam/std", "tinyvec?/std"]
 adjacency = ["dep:tinyvec"]
 shape-extras = []
 libm = ["dep:libm", "glam/libm"]
+serde = ["dep:serde", "tinyvec/serde", "glam/serde"]
 
 [dependencies]
 constgebra = { version = "0.1.4", default-features = false }
 glam = { version = "0.30.0", default-features = false }
 libm = { version = "0.2", optional = true }
+serde = { version = "1.0.219", optional = true, features=["serde_derive"] }
 tinyvec = { version = "1.8.1", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@ pub trait EquilateralBaseShape: BaseShape {
 /// The edge between two main triangles.
 ///
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Edge {
     ///
     /// Indices of the points between the endpoints.
@@ -281,6 +282,7 @@ impl Edge {
 /// shared.
 ///
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum TriangleContents {
     ///
     /// Nothing inside the triangle: subdivisions 0 and 1
@@ -827,6 +829,7 @@ impl TriangleContents {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 ///
 /// A main triangle on the base shape of a subdivided shape.
 ///
@@ -1053,6 +1056,7 @@ impl Triangle {
 /// lie on the unit sphere.
 ///
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Subdivided<T, S: BaseShape> {
     points: Vec<Vec3A>,
     data: Vec<T>,

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -19,6 +19,7 @@ use glam::Vec3A;
 /// then the result will be 12 pentagons and many hexagons.
 ///
 #[derive(Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcoSphereBase;
 
 impl BaseShape for IcoSphereBase {
@@ -90,6 +91,7 @@ impl<T> IcoSphere<T> {
 /// geometric spherical linear interpolation. (`nlerp` over `slerp`).
 ///
 #[derive(Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormIcoSphereBase;
 
 impl BaseShape for NormIcoSphereBase {
@@ -153,6 +155,7 @@ pub type NormIcoSphere<T> = Subdivided<T, NormIcoSphereBase>;
 /// be used for acceptable results.
 ///
 #[derive(Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TetraSphereBase;
 
 impl BaseShape for TetraSphereBase {
@@ -214,6 +217,7 @@ pub type TetraSphere<T> = Subdivided<T, TetraSphereBase>;
 /// circle on the triangle has radius 1.0.
 ///
 #[derive(Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriangleBase;
 
 impl BaseShape for TriangleBase {
@@ -276,6 +280,7 @@ pub type TrianglePlane<T> = Subdivided<T, TriangleBase>;
 /// This is a square on the XZ plane.
 ///
 #[derive(Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SquareBase;
 
 impl BaseShape for SquareBase {
@@ -324,6 +329,7 @@ pub type SquarePlane<T> = Subdivided<T, SquareBase>;
 /// enable this to be used in making a sphere.
 ///
 #[derive(Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CubeBase;
 
 impl BaseShape for CubeBase {


### PR DESCRIPTION
I needed to be able to serialize and deserialize `Subdivided<T, S>`, so I forked the crate and added `serde` as an optional feature.

Since others may have similar needs, and this has no impacts on anyone not using this feature, I told myself that it would be nice to merge this into the main crate!

Of course, if you think this is not a good idea or have arguments against it, feel free to reject this request.

Cheers,
- Virgile