### PR TITLE
Bump glam version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,6 @@ libm = ["dep:libm", "glam/libm"]
 
 [dependencies]
 constgebra = { version = "0.1.4", default-features = false }
-glam = { version = "0.31.0", default-features = false }
+glam = { version = "0.32.0", default-features = false }
 libm = { version = "0.2", optional = true }
 tinyvec = { version = "1.8.1", optional = true, default-features = false }


### PR DESCRIPTION
Bumping major version of glam to 0.32, so to allow `rand` v0.10 transitive dependency to be supported downstream in Bevy.